### PR TITLE
changes to make it compatible with cosmos-sdk v0.40.0-fix8

### DIFF
--- a/module/x/peggy/module.go
+++ b/module/x/peggy/module.go
@@ -66,6 +66,15 @@ func (AppModuleBasic) RegisterRESTRoutes(ctx client.Context, rtr *mux.Router) {
 	rest.RegisterRoutes(ctx, rtr, types.StoreKey)
 }
 
+// TODO:  @Venkatesh, @Albert remove this function after cosmos upgrade
+// RegisterGRPCRoutes registers the gRPC Gateway routes for the orders module.
+func (AppModuleBasic) RegisterGRPCRoutes(clientCtx client.Context, serveMux *runtime.ServeMux) {
+	err := types.RegisterQueryHandlerClient(context.Background(), serveMux, types.NewQueryClient(clientCtx))
+	if err != nil {
+		panic("Failed to RegisterGRPCRoutes in orders module")
+	}
+}
+
 // GetQueryCmd implements app module basic
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd(types.StoreKey)

--- a/module/x/peggy/types/codec.go
+++ b/module/x/peggy/types/codec.go
@@ -4,7 +4,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // ModuleCdc is the codec for the module
@@ -34,7 +33,8 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&MsgWithdrawClaim{},
 	)
 
-	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
+	// TODO: @Venkatesh, @Albert uncomment after cosmos upgrade
+	// msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
 // RegisterCodec registers concrete types on the Amino codec


### PR DESCRIPTION
This PR includes following changes
- Created RegisterGRPCRoutes function in module.go
- Commented  `msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)` in codec.go