### PR TITLE
Update Github actions to run on master or main

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Integration tests
 
 on:
   push:
-    branches: [master, althea-peggy]
+    branches: [master, main]
   pull_request:
-    branches: [master, althea-peggy]
+    branches: [master, main]
 
 jobs:
   happy-path:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [master, althea-peggy]
+    branches: [master, main]
   pull_request:
-    branches: [master, althea-peggy]
+    branches: [master, main]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Solidity contract build and test
 
 on:
   push:
-    branches: [master, althea-peggy]
+    branches: [master, main]
   pull_request:
-    branches: [master, althea-peggy]
+    branches: [master, main]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [master, althea-peggy]
+    branches: [master, main]
   pull_request:
-    branches: [master, althea-peggy]
+    branches: [master, main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I updated the branch names on the upstream Cosmos repository to 'main'
so now the tests don't run as 'main' is not a test triggering branch
name. This patch fixes that and removes references to the 'althea-peggy'
branch which we are no longer using.