### PR TITLE
Cleanup go warnings + Verify signatures before relaying

### DIFF
--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -568,15 +568,33 @@ func (k Keeper) GetBridgeChainID(ctx sdk.Context) uint64 {
 	return a
 }
 
-// GetPeggyID returns the PeggyID (???)
+// GetPeggyID returns the PeggyID the PeggyID is essentially a salt value
+// for bridge signatures, provided each chain running Peggy has a unique ID
+// it won't be possible to play back signatures from one bridge onto another
+// even if they share a validator set.
+//
+// The lifecycle of the PeggyID is that it is set in the Genesis file
+// read from the live chain for the contract deployment, once a Peggy contract
+// is deployed the PeggyID CAN NOT BE CHANGED. Meaning that it can't just be the
+// same as the chain id since the chain id may be changed many times with each
+// successive chain in charge of the same bridge
 func (k Keeper) GetPeggyID(ctx sdk.Context) string {
 	var a string
 	k.paramSpace.Get(ctx, types.ParamsStoreKeyPeggyID, &a)
 	return a
 }
 
-// Set PeggyID sets the PeggyID (couldn't we reuse the ChainID here?)
-func (k Keeper) setPeggyID(ctx sdk.Context, v string) {
+// Set PeggyID sets the PeggyID the PeggyID is essentially a salt value
+// for bridge signatures, provided each chain running Peggy has a unique ID
+// it won't be possible to play back signatures from one bridge onto another
+// even if they share a validator set.
+//
+// The lifecycle of the PeggyID is that it is set in the Genesis file
+// read from the live chain for the contract deployment, once a Peggy contract
+// is deployed the PeggyID CAN NOT BE CHANGED. Meaning that it can't just be the
+// same as the chain id since the chain id may be changed many times with each
+// successive chain in charge of the same bridge
+func (k Keeper) SetPeggyID(ctx sdk.Context, v string) {
 	k.paramSpace.Set(ctx, types.ParamsStoreKeyPeggyID, v)
 }
 

--- a/module/x/peggy/keeper/msg_server.go
+++ b/module/x/peggy/keeper/msg_server.go
@@ -155,12 +155,14 @@ func (k msgServer) RequestBatch(c context.Context, msg *types.MsgRequestBatch) (
 
 	valaddr, _ := sdk.AccAddressFromBech32(msg.Orchestrator)
 	validator := k.GetOrchestratorValidator(ctx, valaddr)
+
+	// a validator request can be sent from a delegate key or a validator
+	// key directly
 	if validator == nil {
 		sval := k.StakingKeeper.Validator(ctx, sdk.ValAddress(valaddr))
 		if sval == nil {
 			return nil, sdkerrors.Wrap(types.ErrUnknown, "validator")
 		}
-		validator = sval.GetOperator()
 	}
 
 	// TODO later make sure that Demon matches a list of tokens already

--- a/module/x/peggy/keeper/querier_test.go
+++ b/module/x/peggy/keeper/querier_test.go
@@ -427,8 +427,7 @@ func TestPendingValsetRequests(t *testing.T) {
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
-			valAddr := sdk.AccAddress{}
-			valAddr = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
+			var valAddr sdk.AccAddress = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
 			got, err := lastPendingValsetRequest(ctx, valAddr.String(), input.PeggyKeeper)
 			require.NoError(t, err)
 			assert.JSONEq(t, string(spec.expResp), string(got), string(got))
@@ -503,8 +502,7 @@ func TestLastPendingBatchRequest(t *testing.T) {
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
-			valAddr := sdk.AccAddress{}
-			valAddr = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
+			var valAddr sdk.AccAddress = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
 			got, err := lastPendingBatchRequest(ctx, valAddr.String(), input.PeggyKeeper)
 			require.NoError(t, err)
 			assert.JSONEq(t, string(spec.expResp), string(got), string(got))
@@ -595,7 +593,7 @@ func TestQueryLogicCalls(t *testing.T) {
 		input.PeggyKeeper.StakingKeeper = NewStakingKeeperMock(validators...)
 	}
 
-	token := []*types.ERC20Token{&types.ERC20Token{
+	token := []*types.ERC20Token{{
 		Contract: tokenContract,
 		Amount:   sdk.NewIntFromUint64(5000),
 	}}
@@ -618,8 +616,7 @@ func TestQueryLogicCalls(t *testing.T) {
 	_, err := lastLogicCallRequests(ctx, k)
 	require.NoError(t, err)
 
-	var valAddr sdk.AccAddress
-	valAddr = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
+	var valAddr sdk.AccAddress = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
 	_, err = lastPendingLogicCallRequest(ctx, valAddr.String(), k)
 	require.NoError(t, err)
 
@@ -652,7 +649,7 @@ func TestQueryLogicCallsConfirms(t *testing.T) {
 		input.PeggyKeeper.StakingKeeper = NewStakingKeeperMock(validators...)
 	}
 
-	token := []*types.ERC20Token{&types.ERC20Token{
+	token := []*types.ERC20Token{{
 		Contract: tokenContract,
 		Amount:   sdk.NewIntFromUint64(5000),
 	}}
@@ -668,8 +665,7 @@ func TestQueryLogicCallsConfirms(t *testing.T) {
 	}
 	k.SetOutgoingLogicCall(ctx, &call)
 
-	var valAddr sdk.AccAddress
-	valAddr = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
+	var valAddr sdk.AccAddress = bytes.Repeat([]byte{byte(1)}, sdk.AddrLen)
 
 	confirm := types.MsgConfirmLogicCall{
 		InvalidationId:    hex.EncodeToString(invalidationId),

--- a/module/x/peggy/keeper/test_common.go
+++ b/module/x/peggy/keeper/test_common.go
@@ -456,6 +456,7 @@ func MintVouchersFromAir(t *testing.T, ctx sdk.Context, k Keeper, dest sdk.AccAd
 	coin := amount.PeggyCoin()
 	vouchers := sdk.Coins{coin}
 	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, vouchers)
+	require.NoError(t, err)
 	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, dest, vouchers)
 	require.NoError(t, err)
 	return coin
@@ -465,7 +466,7 @@ func MintVouchersFromAir(t *testing.T, ctx sdk.Context, k Keeper, dest sdk.AccAd
 func NewStakingKeeperMock(operators ...sdk.ValAddress) *StakingKeeperMock {
 	r := &StakingKeeperMock{
 		BondedValidators: make([]stakingtypes.Validator, 0),
-		ValidatorPower:   make(map[string]int64, 0),
+		ValidatorPower:   make(map[string]int64),
 	}
 	const defaultTestPower = 100
 	for _, a := range operators {

--- a/module/x/peggy/types/batch_test.go
+++ b/module/x/peggy/types/batch_test.go
@@ -56,7 +56,7 @@ func TestOutgoingLogicCallCheckpointGold1(t *testing.T) {
 	invalidationId, err := hex.DecodeString("0x696e76616c69646174696f6e4964000000000000000000000000000000000000"[2:])
 	require.NoError(t, err)
 
-	token := []*ERC20Token{&ERC20Token{
+	token := []*ERC20Token{{
 		Contract: "0xC26eFfa98B8A2632141562Ae7E34953Cfe5B4888",
 		Amount:   sdk.NewIntFromUint64(1),
 	}}

--- a/module/x/peggy/types/genesis.go
+++ b/module/x/peggy/types/genesis.go
@@ -214,14 +214,6 @@ func validateContractHash(i interface{}) error {
 	return nil
 }
 
-func validateStartThreshold(i interface{}) error {
-	// TODO: do we want to validate a range of values here?
-	if _, ok := i.(uint64); !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-	return nil
-}
-
 func validateBridgeChainID(i interface{}) error {
 	if _, ok := i.(uint64); !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "clarity"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55087803a7a5f3db8f61ac95c44ab317f8aba6c3c837bf9c81456c9a92b55371"
+checksum = "5e6e4fd4d89ab771e35070d5a4233f944e7769f44e99ce2c4ea565bd29ac4a6d"
 dependencies = [
  "lazy_static",
  "num-bigint 0.3.1",
@@ -1728,6 +1728,7 @@ dependencies = [
  "rand 0.8.0",
  "serde",
  "serde_derive",
+ "sha3",
  "tokio",
  "tonic",
  "url",

--- a/orchestrator/cosmos_peggy/src/send.rs
+++ b/orchestrator/cosmos_peggy/src/send.rs
@@ -10,7 +10,7 @@ use deep_space::stdfee::StdFee;
 use deep_space::stdsignmsg::StdSignMsg;
 use deep_space::transaction::TransactionSendType;
 use deep_space::{coin::Coin, utils::bytes_to_hex_str};
-use ethereum_peggy::message_signatures::{
+use peggy_utils::message_signatures::{
     encode_logic_call_confirm, encode_tx_batch_confirm, encode_valset_confirm,
 };
 use peggy_utils::types::*;

--- a/orchestrator/ethereum_peggy/src/lib.rs
+++ b/orchestrator/ethereum_peggy/src/lib.rs
@@ -7,7 +7,6 @@ extern crate log;
 
 pub mod deploy_erc20;
 pub mod logic_call;
-pub mod message_signatures;
 pub mod send_to_cosmos;
 pub mod submit_batch;
 pub mod utils;

--- a/orchestrator/peggy_utils/Cargo.toml
+++ b/orchestrator/peggy_utils/Cargo.toml
@@ -21,6 +21,7 @@ tonic = "0.3"
 num-bigint = "0.3"
 log = "0.4"
 url = "2"
+sha3 = "0.9"
 [dev_dependencies]
 rand = "0.8"
 actix = "0.10"

--- a/orchestrator/peggy_utils/src/error.rs
+++ b/orchestrator/peggy_utils/src/error.rs
@@ -25,6 +25,7 @@ pub enum PeggyError {
     InvalidEventLogError(String),
     CosmosgRPCError(Status),
     InsufficientVotingPowerToPass(String),
+    ParseBigIntError(ParseBigIntError),
 }
 
 impl fmt::Display for PeggyError {
@@ -51,6 +52,7 @@ impl fmt::Display for PeggyError {
             PeggyError::InsufficientVotingPowerToPass(val) => {
                 write!(f, "{}", val)
             }
+            PeggyError::ParseBigIntError(val) => write!(f, "Failed to parse big integer {}", val),
         }
     }
 }

--- a/orchestrator/peggy_utils/src/lib.rs
+++ b/orchestrator/peggy_utils/src/lib.rs
@@ -7,4 +7,5 @@ extern crate log;
 
 pub mod connection_prep;
 pub mod error;
+pub mod message_signatures;
 pub mod types;

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -5,6 +5,7 @@ use cosmos_peggy::query::get_transaction_batch_signatures;
 use ethereum_peggy::utils::{downcast_to_u128, get_tx_batch_nonce};
 use ethereum_peggy::{one_eth, submit_batch::send_eth_transaction_batch};
 use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
+use peggy_utils::message_signatures::encode_tx_batch_confirm_hashed;
 use peggy_utils::types::Valset;
 use peggy_utils::types::{BatchConfirmResponse, TransactionBatch};
 use std::time::Duration;
@@ -18,6 +19,7 @@ pub async fn relay_batches(
     web3: &Web3,
     grpc_client: &mut PeggyQueryClient<Channel>,
     peggy_contract_address: EthAddress,
+    peggy_id: String,
     timeout: Duration,
 ) {
     let our_ethereum_address = ethereum_key.to_public_key().unwrap();
@@ -36,7 +38,8 @@ pub async fn relay_batches(
         trace!("Got sigs {:?}", sigs);
         if let Ok(sigs) = sigs {
             // this checks that the signatures for the batch are actually possible to submit to the chain
-            if current_valset.order_sigs(&sigs).is_ok() {
+            let hash = encode_tx_batch_confirm_hashed(peggy_id.clone(), batch.clone());
+            if current_valset.order_sigs(&hash, &sigs).is_ok() {
                 oldest_signed_batch = Some(batch);
                 oldest_signatures = Some(sigs);
             } else {
@@ -83,6 +86,7 @@ pub async fn relay_batches(
             &oldest_signatures,
             web3,
             peggy_contract_address,
+            peggy_id.clone(),
             ethereum_key,
         )
         .await;
@@ -107,6 +111,7 @@ pub async fn relay_batches(
             web3,
             timeout,
             peggy_contract_address,
+            peggy_id,
             ethereum_key,
         )
         .await;

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use clarity::address::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
+use ethereum_peggy::utils::get_peggy_id;
 use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
 use std::time::{Duration, Instant};
 use tokio::time::delay_for;
@@ -38,12 +39,21 @@ pub async fn relayer_main_loop(
         }
         let current_valset = current_valset.unwrap();
 
+        let peggy_id = get_peggy_id(peggy_contract_address, our_ethereum_address, &web3).await;
+        if peggy_id.is_err() {
+            error!("Failed to get PeggyID, check your Eth node");
+            return;
+        }
+        let peggy_id = peggy_id.unwrap();
+        let peggy_id = String::from_utf8(peggy_id.clone()).expect("Invalid PeggyID");
+
         relay_valsets(
             current_valset.clone(),
             ethereum_key,
             &web3,
             &mut grpc_client,
             peggy_contract_address,
+            peggy_id.clone(),
             LOOP_SPEED,
         )
         .await;
@@ -54,6 +64,7 @@ pub async fn relayer_main_loop(
             &web3,
             &mut grpc_client,
             peggy_contract_address,
+            peggy_id.clone(),
             LOOP_SPEED,
         )
         .await;
@@ -64,6 +75,7 @@ pub async fn relayer_main_loop(
             &web3,
             &mut grpc_client,
             peggy_contract_address,
+            peggy_id.clone(),
             LOOP_SPEED,
         )
         .await;


### PR DESCRIPTION
This is two mostly unrelated patches, a very minor cleanup of linter warnings and a much larger refactor of the Orchestrator code to verify all signatures that it recieves to track down an issue that plagued us doing our live demo. 