### PR TITLE
Update Geth and enable Berlin

### DIFF
--- a/tests/assets/ETHGenesis.json
+++ b/tests/assets/ETHGenesis.json
@@ -7,7 +7,9 @@
     "eip158Block": 0,
     "byzantiumBlock": 0,
     "constantinopleBlock": 0,
-    "petersburgBlock": 0
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0
   },
   "difficulty": "0x400",
   "gasLimit": "0xB71B00",

--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -11,9 +11,8 @@ geth --identity "PeggyTestnet" \
 geth --identity "PeggyTestnet" --nodiscover \
 --networkid 15 \
 --mine \
---rpc \
 --http \
---minerthreads=1 \
+--miner.threads=1 \
 --nousb \
 --verbosity=5 \
---etherbase=0xBf660843528035a5A4921534E156a27e64B231fE &> /geth.log
+--miner.etherbase=0xBf660843528035a5A4921534E156a27e64B231fE &> /geth.log

--- a/tests/dockerfile/Dockerfile
+++ b/tests/dockerfile/Dockerfile
@@ -6,7 +6,7 @@ ADD https://golang.org/dl/go1.15.6.linux-amd64.tar.gz /go/
 RUN cd /go && tar -xvf * && mv /go/**/ /usr/local/
 # only required for deployment script
 RUN npm install -g ts-node && npm install -g typescript
-ADD https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.14-6d74d1e5.tar.gz /geth/
+ADD https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.1-c2d2f4ed.tar.gz /geth/
 RUN cd /geth && tar -xvf * && mv /geth/**/geth /usr/bin/geth
 # rust for the testing suite and the relayers / validator daemons
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
Updates Geth to the latest version and enables the Berlin hardfork
on our test chain.