### PR TITLE
Improve test robustness for Javascript code

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -36,6 +36,7 @@ module.exports = {
     }  },
   networks: {
     hardhat: {
+      timeout: 2000000,
       // forking:{
       //   url: `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_ID}`,
       //   blockNumber: 11780000, //Pin random block
@@ -838,6 +839,6 @@ module.exports = {
     enabled: true
   },
   mocha: {
-    timeout: 200000
+    timeout: 2000000
   }
 };


### PR DESCRIPTION
Right now the most unstable part of the tests is either the contract deployer having issues (because the Ethereum chain is not yet up and timing out) or the Ethereum tests timeout in the hardhat test environment, mostly just due to cpu constraints in the testing environment.

This PR is a testing ground for fixes to these problems. 