### PR TITLE
Add block delay for Orchestrator oracle

### DIFF
--- a/orchestrator/orchestrator/src/get_with_retry.rs
+++ b/orchestrator/orchestrator/src/get_with_retry.rs
@@ -1,0 +1,50 @@
+//! Basic utility functions to stubbornly get data
+use clarity::Uint256;
+use cosmos_peggy::query::get_last_event_nonce;
+use deep_space::address::Address as CosmosAddress;
+use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
+use std::time::Duration;
+use tokio::time::delay_for;
+use tonic::transport::Channel;
+use web30::client::Web3;
+
+pub const RETRY_TIME: Duration = Duration::from_secs(5);
+
+/// gets the current block number, no matter how long it takes
+pub async fn get_block_number_with_retry(web3: &Web3) -> Uint256 {
+    let mut res = web3.eth_block_number().await;
+    while res.is_err() {
+        error!("Failed to get latest block! Is your Eth node working?");
+        delay_for(RETRY_TIME).await;
+        res = web3.eth_block_number().await;
+    }
+    res.unwrap()
+}
+
+/// gets the last event nonce, no matter how long it takes.
+pub async fn get_last_event_nonce_with_retry(
+    client: &mut PeggyQueryClient<Channel>,
+    our_cosmos_address: CosmosAddress,
+) -> u64 {
+    let mut res = get_last_event_nonce(client, our_cosmos_address).await;
+    while res.is_err() {
+        error!(
+            "Failed to get last event nonce, is the Cosmos GRPC working? {:?}",
+            res
+        );
+        delay_for(RETRY_TIME).await;
+        res = get_last_event_nonce(client, our_cosmos_address).await;
+    }
+    res.unwrap()
+}
+
+/// gets the net version, no matter how long it takes
+pub async fn get_net_version_with_retry(web3: &Web3) -> u64 {
+    let mut res = web3.net_version().await;
+    while res.is_err() {
+        error!("Failed to get net version! Is your Eth node working?");
+        delay_for(RETRY_TIME).await;
+        res = web3.net_version().await;
+    }
+    res.unwrap()
+}

--- a/orchestrator/orchestrator/src/lib.rs
+++ b/orchestrator/orchestrator/src/lib.rs
@@ -2,5 +2,6 @@
 extern crate log;
 
 pub mod ethereum_event_watcher;
+pub mod get_with_retry;
 pub mod main_loop;
 pub mod oracle_resync;

--- a/orchestrator/orchestrator/src/main.rs
+++ b/orchestrator/orchestrator/src/main.rs
@@ -17,6 +17,7 @@ extern crate lazy_static;
 extern crate log;
 
 mod ethereum_event_watcher;
+mod get_with_retry;
 mod main_loop;
 mod oracle_resync;
 


### PR DESCRIPTION
This patch adds a block delay for POW EVM chains to the orchestrator.

As outlined in the function comment we need this delay to ensure that
chain reogs do ont result in events that "didn't happen" on ethereum
from being observed on Cosmos. I've done some pretty basic napkin math
to compute the shortest amount of time on Ethereum that we can say won't
be caused by a random reorg.

Obviously forks are possible due to client bugs or other issues, but
these in my opinion can be relegated to governance management. Since
claims slashing is removed a disagreement between forks will at worst
halt the Gravity bridge until governance can sort it out. During this
halt validator set updates will continue to be made and relayed, so
funds will not be lost.