### PR TITLE
Fix peggy version string

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -1,5 +1,5 @@
 PACKAGES=$(shell go list ./... | grep -v '/simulation')
-VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
+VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 COMMIT := $(shell git log -1 --format='%H')
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf


### PR DESCRIPTION
This PR fixes an error when running `make install` on the go code and gives a better version string to `peggy`