### PR TITLE
Improve docs for commands to `cosmos-key `-> `cosmos-phrase`

### DIFF
--- a/orchestrator/client/src/main.rs
+++ b/orchestrator/client/src/main.rs
@@ -97,7 +97,7 @@ lazy_static! {
         {} deploy-erc20-representation --cosmos-grpc=<url> --cosmos-denom=<denom> --ethereum-key=<key> --ethereum-rpc=<url> --contract-address=<addr> --erc20-name=<name> --erc20-symbol=<symbol> --erc20-decimals=<decimals>
         Options:
             -h --help                   Show this screen.
-            --cosmos-key=<ckey>         The Cosmos private key of the sender
+            --cosmos-phrase=<ckey>      The mnenmonic of the Cosmos account key of the validator
             --ethereum-key=<ekey>       The Ethereum private key of the sender
             --cosmos-legacy-rpc=<curl>  The Cosmos Legacy RPC url, this will need to be manually enabled
             --cosmos-grpc=<curl>         The Cosmos gRPC url

--- a/orchestrator/orchestrator/src/main.rs
+++ b/orchestrator/orchestrator/src/main.rs
@@ -51,7 +51,7 @@ lazy_static! {
     "Usage: {} --cosmos-phrase=<key> --ethereum-key=<key> --cosmos-legacy-rpc=<url> --cosmos-grpc=<url> --ethereum-rpc=<url> --fees=<denom> --contract-address=<addr>
         Options:
             -h --help                    Show this screen.
-            --cosmos-key=<ckey>          The Cosmos private key of the validator
+            --cosmos-phrase=<ckey>       The mnenmonic of the Cosmos account key of the validator
             --ethereum-key=<ekey>        The Ethereum private key of the validator
             --cosmos-legacy-rpc=<curl>   The Cosmos RPC url, usually the validator
             --cosmos-grpc=<gurl>         The Cosmos gRPC url, usually the validator


### PR DESCRIPTION
Fix the Document comments to correct refer to the `--cosmos-phrase` instead of `--cosmos-key`