### PR TITLE
Compute normalized power difference

### DIFF
--- a/module/x/gravity/types/types.go
+++ b/module/x/gravity/types/types.go
@@ -64,14 +64,24 @@ func (b BridgeValidators) Sort() {
 }
 
 // PowerDiff returns the difference in power between two bridge validator sets
-// TODO: this needs to be potentially refactored
+// note this is Gravity bridge power *not* Cosmos voting power. Cosmos voting
+// power is based on the absolute number of tokens in the staking pool at any given
+// time Gravity bridge power is normalized using the equation.
+//
+// validators cosmos voting power / total cosmos voting power in this block = gravity bridge power / u32_max
+//
+// As an example if someone has 52% of the Cosmos voting power when a validator set is created their Gravity
+// bridge voting power is u32_max * .52
+//
+// Normalized voting power dramatically reduces how often we have to produce new validator set updates. For example
+// if the total on chain voting power increases by 1% due to inflation, we shouldn't have to generate a new validator
+// set, after all the validators retained their relative percentages during inflation and normalized Gravity bridge power
+// shows no difference.
 func (b BridgeValidators) PowerDiff(c BridgeValidators) float64 {
 	powers := map[string]int64{}
-	var totalB int64
 	// loop over b and initialize the map with their powers
 	for _, bv := range b {
 		powers[bv.EthereumAddress] = int64(bv.Power)
-		totalB += int64(bv.Power)
 	}
 
 	// subtract c powers from powers in the map, initializing
@@ -90,7 +100,7 @@ func (b BridgeValidators) PowerDiff(c BridgeValidators) float64 {
 		delta += math.Abs(float64(v))
 	}
 
-	return math.Abs(delta / float64(totalB))
+	return math.Abs(delta / float64(math.MaxUint32))
 }
 
 // TotalPower returns the total power in the bridge validator set

--- a/module/x/gravity/types/types_test.go
+++ b/module/x/gravity/types/types_test.go
@@ -72,16 +72,16 @@ func TestValsetPowerDiff(t *testing.T) {
 		},
 		"one": {
 			start: BridgeValidators{
-				{Power: 1, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
-				{Power: 1, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
-				{Power: 2, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
+				{Power: 1073741823, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
+				{Power: 1073741823, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
+				{Power: 2147483646, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 			},
 			diff: BridgeValidators{
-				{Power: 1, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
-				{Power: 1, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
-				{Power: 3, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
+				{Power: 858993459, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
+				{Power: 858993459, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
+				{Power: 2576980377, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 			},
-			exp: 0.25,
+			exp: 0.2,
 		},
 		"real world": {
 			start: BridgeValidators{
@@ -104,7 +104,7 @@ func TestValsetPowerDiff(t *testing.T) {
 				{Power: 291759231, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 				{Power: 6785098, EthereumAddress: "0x37A0603dA2ff6377E5C7f75698dabA8EE4Ba97B8"},
 			},
-			exp: 0.010000000023283065,
+			exp: 0.010000000011641532,
 		},
 	}
 	for msg, spec := range specs {


### PR DESCRIPTION
The Gravity contract depends on 'normalized' powers. The total amount of Cosmos voting power is summed and divided by 2^32 (uint32 max) and then normalized powers are used for voting.

We've had issues on testnets with the validator set generation code because it uses an absolute ratio of powers change. Which can in some cases **always** be greater than 1% or even 5%. For example if there is very high inflation it's possible that 5% of all staked tokens are actually issued every block. Resulting in the constant creation of new validator sets even though in terms of Gravity bridge normalized powers almost no power has been re-assigned.

This patch changes the power diff function to operate on normalized power differences, like the bridge itself does. This will hopefully cut down on the number of spurious validator set creations.

As a note, epoched staking will not remove the need for a power diff function. On the Cosmos hub for example normalized power changes at the rate of only a few percent a week. Assuming a reasonably sized epoch of 1000 blocks only relying on the Epoch will generate 121 validator sets versus just one which we can ballpark at an extra $5k to relay.