### PR TITLE
Add support for custom prefixes

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -20,8 +20,8 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.6",
  "smallvec",
- "tokio 1.4.0",
- "tokio-util 0.6.5",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
 ]
 
 [[package]]
@@ -52,8 +52,8 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.4.0",
- "tokio-util 0.6.5",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
  "sha-1",
  "smallvec",
  "time 0.2.26",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros 0.2.0",
  "futures-core",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ dependencies = [
  "log",
  "openssl",
  "tokio-openssl 0.6.1",
- "tokio-util 0.6.5",
+ "tokio-util 0.6.6",
 ]
 
 [[package]]
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "589652ce7ccb335d1e7ecb3be145425702b290dbcb7029bbeaae263fc1d87b48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -755,7 +755,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -765,7 +765,7 @@ dependencies = [
  "openssl-probe",
  "serde",
  "serde_derive",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "url",
  "web30",
 ]
@@ -833,7 +833,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "clarity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "env_logger",
  "ethereum_gravity",
  "gravity_proto",
@@ -843,7 +843,7 @@ dependencies = [
  "rand 0.8.3",
  "serde",
  "sha3",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "web30",
 ]
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "deep_space"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49e08c85e480851189263e7c2c4b40a21d16be3291983a8ce13e84224e2a873"
+checksum = "b50a94e36b05397eb6843b899d8d710d262ffc34d5a226f43b15dd36398648a0"
 dependencies = [
  "base64",
  "bech32 0.8.0",
@@ -944,7 +944,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tendermint-proto",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "unicode-normalization",
 ]
@@ -1043,7 +1043,7 @@ name = "ethereum_gravity"
 version = "0.1.0"
 dependencies = [
  "clarity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "gravity_utils",
  "log",
  "num256",
@@ -1124,9 +1124,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1149,15 +1149,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1166,15 +1166,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1184,21 +1184,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1277,7 +1277,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "clarity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "gravity_proto",
  "log",
  "num-bigint 0.4.0",
@@ -1286,7 +1286,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha3",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "url",
  "web30",
@@ -1326,8 +1326,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.4.0",
- "tokio-util 0.6.5",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
  "tracing",
 ]
 
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "httpdate"
@@ -1434,7 +1434,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.6",
  "socket2 0.4.0",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tower-service",
  "tracing",
  "want",
@@ -1953,7 +1953,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -1970,7 +1970,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "web30",
 ]
@@ -2343,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -2375,7 +2375,7 @@ dependencies = [
  "clarity",
  "contact",
  "cosmos_gravity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -2398,7 +2398,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -2410,7 +2410,7 @@ dependencies = [
  "openssl-probe",
  "serde",
  "serde_derive",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "web30",
 ]
@@ -2774,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2844,7 +2844,7 @@ dependencies = [
  "actix-web",
  "clarity",
  "cosmos_gravity",
- "deep_space 1.1.0",
+ "deep_space 2.1.1",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -2858,7 +2858,7 @@ dependencies = [
  "rand 0.8.3",
  "serde",
  "serde_derive",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tonic",
  "url",
  "web30",
@@ -2978,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3025,7 +3025,7 @@ dependencies = [
  "futures",
  "openssl",
  "pin-project 1.0.6",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -3036,7 +3036,7 @@ checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -3055,23 +3055,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.2.6",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
+checksum = "556dc31b450f45d18279cfc3d2519280273f460d5387e6b7b24503e65d206f8b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3087,9 +3087,9 @@ dependencies = [
  "pin-project 1.0.6",
  "prost",
  "prost-derive",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tokio-stream",
- "tokio-util 0.6.5",
+ "tokio-util 0.6.6",
  "tower",
  "tower-service",
  "tracing",
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e09854abff4c0716059219e155ab0539aecbfc26a40214897b062653adb6ba"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -3120,9 +3120,9 @@ dependencies = [
  "pin-project 1.0.6",
  "rand 0.8.3",
  "slab",
- "tokio 1.4.0",
+ "tokio 1.5.0",
  "tokio-stream",
- "tokio-util 0.6.5",
+ "tokio-util 0.6.6",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3403,7 +3403,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 1.4.0",
+ "tokio 1.5.0",
 ]
 
 [[package]]

--- a/orchestrator/client/Cargo.toml
+++ b/orchestrator/client/Cargo.toml
@@ -10,7 +10,7 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/client/src/main.rs
+++ b/orchestrator/client/src/main.rs
@@ -83,6 +83,7 @@ struct Args {
     flag_erc20_name: String,
     flag_erc20_symbol: String,
     flag_erc20_decimals: u8,
+    flag_cosmos_prefix: String,
     cmd_eth_to_cosmos: bool,
     cmd_cosmos_to_eth: bool,
     cmd_deploy_erc20_representation: bool,
@@ -91,15 +92,16 @@ struct Args {
 lazy_static! {
     pub static ref USAGE: String = format!(
     "Usage:
-        {} cosmos-to-eth --cosmos-phrase=<key> --cosmos-grpc=<url> --cosmos-denom=<denom> --amount=<amount> --eth-destination=<dest> [--no-batch] [--times=<number>]
-        {} eth-to-cosmos --ethereum-key=<key> --ethereum-rpc=<url> --contract-address=<addr> --erc20-address=<addr> --amount=<amount> --cosmos-destination=<dest> [--times=<number>]
-        {} deploy-erc20-representation --cosmos-grpc=<url> --cosmos-denom=<denom> --ethereum-key=<key> --ethereum-rpc=<url> --contract-address=<addr> --erc20-name=<name> --erc20-symbol=<symbol> --erc20-decimals=<decimals>
+        {} cosmos-to-eth --cosmos-phrase=<key> --cosmos-grpc=<url> --cosmos-prefix=<prefix> --cosmos-denom=<denom> --amount=<amount> --eth-destination=<dest> [--no-batch] [--times=<number>]
+        {} eth-to-cosmos --ethereum-key=<key> --ethereum-rpc=<url> --cosmos-prefix=<prefix> --contract-address=<addr> --erc20-address=<addr> --amount=<amount> --cosmos-destination=<dest> [--times=<number>]
+        {} deploy-erc20-representation --cosmos-grpc=<url> --cosmos-prefix=<prefix> --cosmos-denom=<denom> --ethereum-key=<key> --ethereum-rpc=<url> --contract-address=<addr> --erc20-name=<name> --erc20-symbol=<symbol> --erc20-decimals=<decimals>
         Options:
             -h --help                   Show this screen.
             --cosmos-phrase=<ckey>      The mnenmonic of the Cosmos account key of the validator
             --ethereum-key=<ekey>       The Ethereum private key of the sender
             --cosmos-legacy-rpc=<curl>  The Cosmos Legacy RPC url, this will need to be manually enabled
-            --cosmos-grpc=<curl>         The Cosmos gRPC url
+            --cosmos-grpc=<curl>        The Cosmos gRPC url
+            --cosmos-prefix=<prefix>    The Bech32 Prefix used for the Cosmos chain's addresses
             --ethereum-rpc=<eurl>       The Ethereum RPC url, should be a self hosted node
             --contract-address=<addr>   The Ethereum contract address for Gravity, this is temporary
             --erc20-address=<addr>      An erc20 address on Ethereum to send funds from
@@ -111,7 +113,7 @@ lazy_static! {
             --times=<number>            The number of times this send should be preformed, useful for stress testing
             --erc20-name=<name>         The 'name' value for the deployed ERC20 contract, must match Cosmos denom metadata
             --erc20-symbol=<symbol>     The 'symbol 'value for the deployed ERC20 contract, must match the Cosmos denom metadata
-            --erc20-decimals=<decimals> The number of decimals the deployed ERC20 token will have, must match the resolution of the Cosmos asset to be adopted by the chain   
+            --erc20-decimals=<decimals> The number of decimals the deployed ERC20 token will have, must match the resolution of the Cosmos asset to be adopted by the chain  
         Description:
             cosmos-to-eth               Locks up a Cosmos asset in the batch pool. Optionally this command will also request a batch.
             eth-to-cosmos               Sends an Ethereum ERC20 asset to a Cosmos destination address
@@ -155,10 +157,16 @@ async fn main() {
         };
         let cosmos_key = CosmosPrivateKey::from_phrase(&args.flag_cosmos_phrase, "")
             .expect("Failed to parse cosmos key phrase, does it have a password?");
-        let cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+        let cosmos_address = cosmos_key.to_address(&args.flag_cosmos_prefix).unwrap();
 
         println!("Sending from Cosmos address {}", cosmos_address);
-        let connections = create_rpc_connections(Some(args.flag_cosmos_grpc), None, TIMEOUT).await;
+        let connections = create_rpc_connections(
+            args.flag_cosmos_prefix,
+            Some(args.flag_cosmos_grpc),
+            None,
+            TIMEOUT,
+        )
+        .await;
         let contact = connections.contact.unwrap();
         let mut grpc = connections.grpc.unwrap();
 
@@ -265,7 +273,13 @@ async fn main() {
             .flag_contract_address
             .parse()
             .expect("Invalid contract address!");
-        let connections = create_rpc_connections(None, Some(args.flag_ethereum_rpc), TIMEOUT).await;
+        let connections = create_rpc_connections(
+            args.flag_cosmos_prefix,
+            None,
+            Some(args.flag_ethereum_rpc),
+            TIMEOUT,
+        )
+        .await;
         let web3 = connections.web3.unwrap();
         let cosmos_dest: CosmosAddress = args.flag_cosmos_destination.parse().unwrap();
         let ethereum_public_key = ethereum_key.to_public_key().unwrap();
@@ -330,6 +344,7 @@ async fn main() {
             .parse()
             .expect("Invalid contract address!");
         let connections = create_rpc_connections(
+            args.flag_cosmos_prefix,
             Some(args.flag_cosmos_grpc),
             Some(args.flag_ethereum_rpc),
             TIMEOUT,

--- a/orchestrator/cosmos_gravity/Cargo.toml
+++ b/orchestrator/cosmos_gravity/Cargo.toml
@@ -11,7 +11,7 @@ gravity_utils = {path = "../gravity_utils"}
 ethereum_gravity = {path = "../ethereum_gravity"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 clarity = "0.4"
 serde = "1.0"
 num256 = "0.3"

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -42,15 +42,11 @@ pub async fn update_gravity_delegate_addresses(
 ) -> Result<TxResponse, CosmosGrpcError> {
     trace!("Updating Gravity Delegate addresses");
     let our_valoper_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address()
+        .to_address(&contact.get_prefix())
+        .unwrap()
         .to_bech32("cosmosvaloper")
         .unwrap();
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
 
     let msg_set_orch_address = MsgSetOrchestratorAddress {
         validator: our_valoper_address.to_string(),
@@ -100,10 +96,7 @@ pub async fn send_valset_confirms(
     private_key: PrivateKey,
     gravity_id: String,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
     let our_eth_address = eth_private_key.to_public_key().unwrap();
 
     let fee = Fee {
@@ -161,10 +154,7 @@ pub async fn send_batch_confirm(
     private_key: PrivateKey,
     gravity_id: String,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
     let our_eth_address = eth_private_key.to_public_key().unwrap();
 
     let fee = Fee {
@@ -223,10 +213,7 @@ pub async fn send_logic_call_confirm(
     private_key: PrivateKey,
     gravity_id: String,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
     let our_eth_address = eth_private_key.to_public_key().unwrap();
 
     let fee = Fee {
@@ -285,10 +272,7 @@ pub async fn send_ethereum_claims(
     logic_calls: Vec<LogicCallExecutedEvent>,
     fee: Coin,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
 
     // This sorts oracle messages by event nonce before submitting them. It's not a pretty implementation because
     // we're missing an intermediary layer of abstraction. We could implement 'EventTrait' and then implement sort
@@ -394,10 +378,7 @@ pub async fn send_to_eth(
     fee: Coin,
     contact: &Contact,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
     if amount.denom != fee.denom {
         return Err(CosmosGrpcError::BadInput(format!(
             "{} {} is an invalid denom set for SendToEth you must pay fees in the same token your sending",
@@ -466,10 +447,7 @@ pub async fn send_request_batch(
     fee: Coin,
     contact: &Contact,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let our_address = private_key
-        .to_public_key()
-        .expect("Invalid private key!")
-        .to_address();
+    let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
 
     let msg_request_batch = MsgRequestBatch {
         sender: our_address.to_string(),

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -44,7 +44,11 @@ pub async fn update_gravity_delegate_addresses(
     let our_valoper_address = private_key
         .to_address(&contact.get_prefix())
         .unwrap()
-        .to_bech32("cosmosvaloper")
+        // This works so long as the format set by the cosmos hub is maintained
+        // having a main prefix followed by a series of titles for specific keys
+        // this will not work if that convention is broken. This will be resolved when
+        // GRPC exposes prefix endpoints (coming to upstream cosmos sdk soon)
+        .to_bech32(format!("{}valoper", contact.get_prefix()))
         .unwrap();
     let our_address = private_key.to_address(&contact.get_prefix()).unwrap();
 

--- a/orchestrator/ethereum_gravity/Cargo.toml
+++ b/orchestrator/ethereum_gravity/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 gravity_utils = {path = "../gravity_utils"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 clarity = "0.4"
 web30 = "0.12"
 num256 = "0.3"

--- a/orchestrator/ethereum_gravity/src/utils.rs
+++ b/orchestrator/ethereum_gravity/src/utils.rs
@@ -25,7 +25,10 @@ pub fn get_correct_sig_for_address(
     panic!("Could not find that address!");
 }
 
-pub fn get_checkpoint_abi_encode(valset: &Valset, gravity_id: &str) -> Result<Vec<u8>, GravityError> {
+pub fn get_checkpoint_abi_encode(
+    valset: &Valset,
+    gravity_id: &str,
+) -> Result<Vec<u8>, GravityError> {
     let (eth_addresses, powers) = valset.filter_empty_addresses();
     Ok(encode_tokens(&[
         Token::FixedString(gravity_id.to_string()),

--- a/orchestrator/gravity_utils/Cargo.toml
+++ b/orchestrator/gravity_utils/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 web30 = "0.12"
 clarity = "0.4"
 num256 = "0.3"

--- a/orchestrator/gravity_utils/src/connection_prep.rs
+++ b/orchestrator/gravity_utils/src/connection_prep.rs
@@ -26,6 +26,7 @@ pub struct Connections {
 /// operation in a error resilient manner. TODO find some way to generalize
 /// this so that it's less ugly
 pub async fn create_rpc_connections(
+    chain_prefix: String,
     grpc_url: Option<String>,
     eth_rpc_url: Option<String>,
     timeout: Duration,
@@ -61,12 +62,12 @@ pub async fn create_rpc_connections(
                     match (ipv4, ipv6) {
                         (Ok(v), Err(_)) => {
                             info!("Url fallback succeeded, your cosmos gRPC url {} has been corrected to {}", grpc_url, ipv4_url);
-                            contact = Some(Contact::new(&ipv4_url, timeout));
+                            contact = Some(Contact::new(&ipv4_url, timeout, &chain_prefix).unwrap());
                             grpc = Some(v)
                         },
                         (Err(_), Ok(v)) => {
                             info!("Url fallback succeeded, your cosmos gRPC url {} has been corrected to {}", grpc_url, ipv6_url);
-                            contact = Some(Contact::new(&ipv6_url, timeout));
+                            contact = Some(Contact::new(&ipv6_url, timeout, &chain_prefix).unwrap());
                             grpc = Some(v)
                         },
                         (Ok(_), Ok(_)) => panic!("This should never happen? Why didn't things work the first time?"),
@@ -88,12 +89,12 @@ pub async fn create_rpc_connections(
                     match (https_on_80, https_on_443) {
                         (Ok(v), Err(_)) => {
                             info!("Https upgrade succeeded, your cosmos gRPC url {} has been corrected to {}", grpc_url, https_on_80_url);
-                            contact = Some(Contact::new(&https_on_80_url, timeout));
+                            contact = Some(Contact::new(&https_on_80_url, timeout, &chain_prefix).unwrap());
                             grpc = Some(v)
                         },
                         (Err(_), Ok(v)) => {
                             info!("Https upgrade succeeded, your cosmos gRPC url {} has been corrected to {}", grpc_url, https_on_443_url);
-                            contact = Some(Contact::new(&https_on_443_url, timeout));
+                            contact = Some(Contact::new(&https_on_443_url, timeout, &chain_prefix).unwrap());
                             grpc = Some(v)
                         },
                         (Ok(_), Ok(_)) => panic!("This should never happen? Why didn't things work the first time?"),

--- a/orchestrator/gravity_utils/src/message_signatures.rs
+++ b/orchestrator/gravity_utils/src/message_signatures.rs
@@ -141,7 +141,7 @@ fn test_batch_signature() {
     let erc20_addr = "0x835973768750b3ED2D5c3EF5AdcD5eDb44d12aD4"
         .parse()
         .unwrap();
-    let sender_addr = "0x527FBEE652609AB150F0AEE9D61A2F76CFC4A73E"
+    let sender_addr = "althea1c8nkaxk3d0p2gd7ummvmyqpdvqd6pkehqhwnnt"
         .parse()
         .unwrap();
 

--- a/orchestrator/gravity_utils/src/types/batches.rs
+++ b/orchestrator/gravity_utils/src/types/batches.rs
@@ -6,7 +6,7 @@ use deep_space::Address as CosmosAddress;
 
 /// This represents an individual transaction being bridged over to Ethereum
 /// parallel is the OutgoingTransferTx in x/gravity/types/batch.go
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BatchTransaction {
     pub id: u64,
     pub sender: CosmosAddress,
@@ -99,7 +99,7 @@ impl TransactionBatch {
 }
 
 /// the response we get when querying for a batch confirmation
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BatchConfirmResponse {
     pub nonce: u64,
     pub orchestrator: CosmosAddress,

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -187,7 +187,7 @@ impl TransactionBatchExecutedEvent {
 
 /// A parsed struct representing the Ethereum event fired when someone makes a deposit
 /// on the Gravity contract
-#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SendToCosmosEvent {
     /// The token contract address for the deposit
     pub erc20: EthAddress,
@@ -217,7 +217,8 @@ impl SendToCosmosEvent {
             // create an address from bytes.
             let mut c_address_bytes: [u8; 20] = [0; 20];
             c_address_bytes.copy_from_slice(&destination_data[12..32]);
-            let destination = CosmosAddress::from_bytes(c_address_bytes);
+            let destination =
+                CosmosAddress::from_bytes(c_address_bytes, CosmosAddress::DEFAULT_PREFIX).unwrap();
             let amount = Uint256::from_bytes_be(&input.data[..32]);
             let event_nonce = Uint256::from_bytes_be(&input.data[32..]);
             let block_height = if let Some(bn) = input.block_number.clone() {

--- a/orchestrator/gravity_utils/src/types/logic_call.rs
+++ b/orchestrator/gravity_utils/src/types/logic_call.rs
@@ -53,7 +53,7 @@ impl LogicCall {
 }
 
 /// the response we get when querying for a logic call confirmation
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LogicCallConfirmResponse {
     pub invalidation_id: Vec<u8>,
     pub invalidation_nonce: u64,

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -51,7 +51,7 @@ struct SignatureStatus {
 }
 
 /// the response we get when querying for a valset confirmation
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ValsetConfirmResponse {
     pub orchestrator: CosmosAddress,
     pub eth_address: EthAddress,

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -19,7 +19,7 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -29,7 +29,7 @@ pub async fn check_for_events(
     fee: Coin,
     starting_block: Uint256,
 ) -> Result<Uint256, GravityError> {
-    let our_cosmos_address = our_private_key.to_public_key().unwrap().to_address();
+    let our_cosmos_address = our_private_key.to_address(&contact.get_prefix()).unwrap();
     let latest_block = get_block_number_with_retry(web3).await;
     let latest_block = latest_block - get_block_delay(web3).await;
 

--- a/orchestrator/orchestrator/src/main.rs
+++ b/orchestrator/orchestrator/src/main.rs
@@ -40,6 +40,7 @@ struct Args {
     flag_cosmos_phrase: String,
     flag_ethereum_key: String,
     flag_cosmos_grpc: String,
+    flag_cosmos_prefix: String,
     flag_ethereum_rpc: String,
     flag_contract_address: String,
     flag_fees: String,
@@ -47,12 +48,13 @@ struct Args {
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-    "Usage: {} --cosmos-phrase=<key> --ethereum-key=<key> --cosmos-grpc=<url> --ethereum-rpc=<url> --fees=<denom> --contract-address=<addr>
+    "Usage: {} --cosmos-phrase=<key> --ethereum-key=<key> --cosmos-grpc=<url> --cosmos-prefix=<prefix> --ethereum-rpc=<url> --fees=<denom> --contract-address=<addr>
         Options:
             -h --help                    Show this screen.
             --cosmos-phrase=<ckey>       The mnenmonic of the Cosmos account key of the validator
             --ethereum-key=<ekey>        The Ethereum private key of the validator
             --cosmos-grpc=<gurl>         The Cosmos gRPC url, usually the validator
+            --cosmos-prefix=<prefix>       The prefix for addresses on this Cosmos chain
             --ethereum-rpc=<eurl>        The Ethereum RPC url, should be a self hosted node
             --fees=<denom>               The Cosmos Denom in which to pay Cosmos chain fees
             --contract-address=<addr>    The Ethereum contract address for Gravity, this is temporary
@@ -97,28 +99,26 @@ async fn main() {
 
     // probe all rpc connections and see if they are valid
     let connections = create_rpc_connections(
+        args.flag_cosmos_prefix,
         Some(args.flag_cosmos_grpc),
         Some(args.flag_ethereum_rpc),
         timeout,
     )
     .await;
 
+    let mut grpc = connections.grpc.clone().unwrap();
+    let contact = connections.contact.clone().unwrap();
+    let web3 = connections.web3.clone().unwrap();
+
     let public_eth_key = ethereum_key
         .to_public_key()
         .expect("Invalid Ethereum Private Key!");
-    let public_cosmos_key = cosmos_key
-        .to_public_key()
-        .expect("Invalid Cosmos Phrase!")
-        .to_address();
+    let public_cosmos_key = cosmos_key.to_address(&contact.get_prefix()).unwrap();
     info!("Starting Gravity Validator companion binary Relayer + Oracle + Eth Signer");
     info!(
         "Ethereum Address: {} Cosmos Address {}",
         public_eth_key, public_cosmos_key
     );
-
-    let mut grpc = connections.grpc.clone().unwrap();
-    let contact = connections.contact.clone().unwrap();
-    let web3 = connections.web3.clone().unwrap();
 
     // check if the cosmos node is syncing, if so wait for it
     // we can't move any steps above this because they may fail on an incorrect

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -88,7 +88,7 @@ pub async fn eth_oracle_main_loop(
     gravity_contract_address: EthAddress,
     fee: Coin,
 ) {
-    let our_cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+    let our_cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
     let long_timeout_web30 = Web3::new(&web3.get_url(), Duration::from_secs(120));
     let mut last_checked_block: Uint256 = get_last_checked_block(
         grpc_client.clone(),
@@ -181,7 +181,7 @@ pub async fn eth_signer_main_loop(
     gravity_contract_address: EthAddress,
     fee: Coin,
 ) {
-    let our_cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+    let our_cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
     let our_ethereum_address = ethereum_key.to_public_key().unwrap();
     let mut grpc_client = grpc_client;
     let gravity_id = get_gravity_id(gravity_contract_address, our_ethereum_address, &web3).await;

--- a/orchestrator/register_delegate_keys/Cargo.toml
+++ b/orchestrator/register_delegate_keys/Cargo.toml
@@ -15,7 +15,7 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"

--- a/orchestrator/register_delegate_keys/src/main.rs
+++ b/orchestrator/register_delegate_keys/src/main.rs
@@ -19,21 +19,21 @@ struct Args {
     flag_validator_phrase: String,
     flag_cosmos_phrase: Option<String>,
     flag_ethereum_key: Option<String>,
-    flag_cosmos_prefix: String,
-    flag_cosmos_rpc: String,
+    flag_address_prefix: String,
+    flag_cosmos_grpc: String,
     flag_fees: String,
 }
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-        "Usage: {} --validator-phrase=<key> --cosmos-prefix=<prefix> [--cosmos-phrase=<key>] [--ethereum-key=<key>] --cosmos-rpc=<url> --fees=<denom>
+        "Usage: {} --validator-phrase=<key> --address-prefix=<prefix> [--cosmos-phrase=<key>] [--ethereum-key=<key>] --cosmos-grpc=<url> --fees=<denom>
         Options:
             -h --help                 Show this screen.
             --validator-phrase=<vkey> The Cosmos private key of the validator. Must be saved when you generate your key
             --ethereum-key=<ekey>     (Optional) The Ethereum private key to register, will be generated if not provided
             --cosmos-phrase=<ckey>    (Optional) The phrase for the Cosmos key to register, will be generated if not provided.
-            --cosos-prefix=<prefix>   The phrase for Addresses on this chain (eg 'cosmos')
-            --cosmos-rpc=<curl>       The Cosmos Legacy RPC url, usually the validator. This will need to be manually enabled
+            --address-prefix=<prefix> The prefix for Addresses on this chain (eg 'cosmos')
+            --cosmos-grpc=<curl>      The Cosmos RPC url, usually the validator. This will need to be manually enabled
             --fees=<denom>            The Cosmos Denom in which to pay Cosmos chain fees
         About:
             Special purpose binary for bootstrapping Gravity chains. This will submit and optionally
@@ -68,8 +68,8 @@ async fn main() {
     };
 
     let connections = create_rpc_connections(
-        args.flag_cosmos_prefix,
-        Some(args.flag_cosmos_rpc),
+        args.flag_address_prefix,
+        Some(args.flag_cosmos_grpc),
         None,
         TIMEOUT,
     )

--- a/orchestrator/register_delegate_keys/src/main.rs
+++ b/orchestrator/register_delegate_keys/src/main.rs
@@ -19,18 +19,20 @@ struct Args {
     flag_validator_phrase: String,
     flag_cosmos_phrase: Option<String>,
     flag_ethereum_key: Option<String>,
+    flag_cosmos_prefix: String,
     flag_cosmos_rpc: String,
     flag_fees: String,
 }
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-        "Usage: {} --validator-phrase=<key> [--cosmos-phrase=<key>] [--ethereum-key=<key>] --cosmos-rpc=<url> --fees=<denom>
+        "Usage: {} --validator-phrase=<key> --cosmos-prefix=<prefix> [--cosmos-phrase=<key>] [--ethereum-key=<key>] --cosmos-rpc=<url> --fees=<denom>
         Options:
-            -h --help                     Show this screen.
-            --validator-phrase=<vkey>    The Cosmos private key of the validator. Must be saved when you generate your key
+            -h --help                 Show this screen.
+            --validator-phrase=<vkey> The Cosmos private key of the validator. Must be saved when you generate your key
             --ethereum-key=<ekey>     (Optional) The Ethereum private key to register, will be generated if not provided
             --cosmos-phrase=<ckey>    (Optional) The phrase for the Cosmos key to register, will be generated if not provided.
+            --cosos-prefix=<prefix>   The phrase for Addresses on this chain (eg 'cosmos')
             --cosmos-rpc=<curl>       The Cosmos Legacy RPC url, usually the validator. This will need to be manually enabled
             --fees=<denom>            The Cosmos Denom in which to pay Cosmos chain fees
         About:
@@ -65,26 +67,30 @@ async fn main() {
         amount: 1u64.into(),
     };
 
-    let connections = create_rpc_connections(Some(args.flag_cosmos_rpc), None, TIMEOUT).await;
+    let connections = create_rpc_connections(
+        args.flag_cosmos_prefix,
+        Some(args.flag_cosmos_rpc),
+        None,
+        TIMEOUT,
+    )
+    .await;
     let contact = connections.contact.unwrap();
     wait_for_cosmos_node_ready(&contact).await;
 
     let validator_key = CosmosPrivateKey::from_phrase(&args.flag_validator_phrase, "")
         .expect("Failed to parse validator key");
-    let validator_addr = validator_key.to_public_key().unwrap().to_address();
+    let validator_addr = validator_key.to_address(&contact.get_prefix()).unwrap();
     check_for_fee_denom(&fee_denom, validator_addr, &contact).await;
 
     let cosmos_key = if let Some(cosmos_phrase) = args.flag_cosmos_phrase {
         CosmosPrivateKey::from_phrase(&cosmos_phrase, "").expect("Failed to parse cosmos key")
     } else {
         let new_phrase = Mnemonic::generate(24).unwrap();
-        let key =
-            CosmosPrivateKey::from_hd_wallet_path("m/44'/118'/0'/0/0", new_phrase.as_str(), "")
-                .unwrap();
+        let key = CosmosPrivateKey::from_phrase(new_phrase.as_str(), "").unwrap();
         println!(
             "No Cosmos key provided, your generated key is\n {} -> {}",
             new_phrase.as_str(),
-            key.to_public_key().unwrap().to_address()
+            key.to_address(&contact.get_prefix()).unwrap()
         );
         key
     };
@@ -103,7 +109,7 @@ async fn main() {
     };
 
     let ethereum_address = ethereum_key.to_public_key().unwrap();
-    let cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+    let cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
     update_gravity_delegate_addresses(
         &contact,
         ethereum_address,
@@ -115,7 +121,6 @@ async fn main() {
     .expect("Failed to update Eth address");
 
     let eth_address = ethereum_key.to_public_key().unwrap();
-    let cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
     println!(
         "Registered Delegate Ethereum address {} and Cosmos address {}",
         eth_address, cosmos_address

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -18,7 +18,7 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -25,17 +25,19 @@ extern crate log;
 struct Args {
     flag_ethereum_key: String,
     flag_cosmos_grpc: String,
+    flag_cosmos_prefix: String,
     flag_ethereum_rpc: String,
     flag_contract_address: String,
 }
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-    "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --ethereum-rpc=<url> --contract-address=<addr>
+    "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --cosmos-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr>
         Options:
             -h --help                    Show this screen.
             --ethereum-key=<ekey>        An Ethereum private key containing non-trivial funds
             --cosmos-grpc=<gurl>         The Cosmos gRPC url
+            --cosmos-prefix=<prefix>       The prefix for addresses on this Cosmos chain
             --ethereum-rpc=<eurl>        The Ethereum RPC url, Geth light clients work and sync fast
             --contract-address=<addr>    The Ethereum contract address for Gravity
         About:
@@ -71,6 +73,7 @@ async fn main() {
         .expect("Invalid contract address!");
 
     let connections = create_rpc_connections(
+        args.flag_cosmos_prefix,
         Some(args.flag_cosmos_grpc),
         Some(args.flag_ethereum_rpc),
         LOOP_SPEED,

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -25,20 +25,20 @@ extern crate log;
 struct Args {
     flag_ethereum_key: String,
     flag_cosmos_grpc: String,
-    flag_cosmos_prefix: String,
+    flag_address_prefix: String,
     flag_ethereum_rpc: String,
     flag_contract_address: String,
 }
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-    "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --cosmos-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr>
+    "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --address-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr> --cosmos-grpc=<gurl>
         Options:
             -h --help                    Show this screen.
             --ethereum-key=<ekey>        An Ethereum private key containing non-trivial funds
             --cosmos-grpc=<gurl>         The Cosmos gRPC url
-            --cosmos-prefix=<prefix>       The prefix for addresses on this Cosmos chain
-            --ethereum-rpc=<eurl>        The Ethereum RPC url, Geth light clients work and sync fast
+            --address-prefix=<prefix>    The prefix for addresses on this Cosmos chain
+            --ethereum-grpc=<eurl>       The Ethereum RPC url, Geth light clients work and sync fast
             --contract-address=<addr>    The Ethereum contract address for Gravity
         About:
             The Gravity relayer component, responsible for relaying data from the Cosmos blockchain
@@ -73,7 +73,7 @@ async fn main() {
         .expect("Invalid contract address!");
 
     let connections = create_rpc_connections(
-        args.flag_cosmos_prefix,
+        args.flag_address_prefix,
         Some(args.flag_cosmos_grpc),
         Some(args.flag_ethereum_rpc),
         LOOP_SPEED,

--- a/orchestrator/test_runner/Cargo.toml
+++ b/orchestrator/test_runner/Cargo.toml
@@ -16,7 +16,7 @@ gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 orchestrator = {path = "../orchestrator/"}
 
-deep_space = "1.1"
+deep_space = "2.1"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -60,9 +60,8 @@ pub async fn happy_path_test(
     let secret: [u8; 32] = rng.gen();
     let dest_cosmos_private_key = CosmosPrivateKey::from_secret(&secret);
     let dest_cosmos_address = dest_cosmos_private_key
-        .to_public_key()
-        .unwrap()
-        .to_address();
+        .to_address(CosmosAddress::DEFAULT_PREFIX)
+        .unwrap();
     let dest_eth_private_key = EthPrivateKey::from_slice(&secret).unwrap();
     let dest_eth_address = dest_eth_private_key.to_public_key().unwrap();
 
@@ -212,11 +211,9 @@ pub async fn test_valset_update(web30: &Web3, keys: &[ValidatorKeys], gravity_ad
     let validator_to_change = rng.gen_range(0..keys.len());
     let delegate_address = &keys[validator_to_change]
         .validator_key
-        .to_public_key()
+        .to_address("cosmosvaloper")
         .unwrap()
-        .to_address()
-        .to_bech32("cosmosvaloper")
-        .unwrap();
+        .to_string();
     let amount = &format!("{}stake", STARTING_STAKE_PER_VALIDATOR / 4);
     info!(
         "Delegating {} to {} in order to generate a validator set update",
@@ -322,9 +319,8 @@ async fn test_batch(
     erc20_contract: EthAddress,
 ) {
     let dest_cosmos_address = dest_cosmos_private_key
-        .to_public_key()
-        .unwrap()
-        .to_address();
+        .to_address(&contact.get_prefix())
+        .unwrap();
     let coin = check_cosmos_balance("gravity", dest_cosmos_address, &contact)
         .await
         .unwrap();
@@ -366,9 +362,8 @@ async fn test_batch(
 
     contact.wait_for_next_block(TOTAL_TIMEOUT).await.unwrap();
     let requester_address = requester_cosmos_private_key
-        .to_public_key()
-        .unwrap()
-        .to_address();
+        .to_address(&contact.get_prefix())
+        .unwrap();
     get_oldest_unsigned_transaction_batch(grpc_client, requester_address)
         .await
         .expect("Failed to get batch to sign");

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -15,6 +15,7 @@ use clarity::PrivateKey as EthPrivateKey;
 use clarity::{Address as EthAddress, Uint256};
 use cosmos_gravity::utils::wait_for_cosmos_online;
 use deep_space::coin::Coin;
+use deep_space::Address as CosmosAddress;
 use deep_space::Contact;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
 use happy_path::happy_path_test;
@@ -98,7 +99,12 @@ pub fn should_deploy_contracts() -> bool {
 pub async fn main() {
     env_logger::init();
     info!("Staring Gravity test-runner");
-    let contact = Contact::new(COSMOS_NODE_GRPC, OPERATION_TIMEOUT);
+    let contact = Contact::new(
+        COSMOS_NODE_GRPC,
+        OPERATION_TIMEOUT,
+        CosmosAddress::DEFAULT_PREFIX,
+    )
+    .unwrap();
 
     info!("Waiting for Cosmos chain to come online");
     wait_for_cosmos_online(&contact, TOTAL_TIMEOUT).await;
@@ -126,7 +132,10 @@ pub async fn main() {
 
     assert!(check_cosmos_balance(
         &get_test_token_name(),
-        keys[0].validator_key.to_public_key().unwrap().to_address(),
+        keys[0]
+            .validator_key
+            .to_address(&contact.get_prefix())
+            .unwrap(),
         &contact
     )
     .await
@@ -157,7 +166,12 @@ pub async fn main() {
             .await;
             return;
         } else if test_type == "BATCH_STRESS" {
-            let contact = Contact::new(COSMOS_NODE_GRPC, TOTAL_TIMEOUT);
+            let contact = Contact::new(
+                COSMOS_NODE_GRPC,
+                TOTAL_TIMEOUT,
+                CosmosAddress::DEFAULT_PREFIX,
+            )
+            .unwrap();
             transaction_stress_test(&web30, &contact, keys, gravity_address, erc20_addresses).await;
             return;
         } else if test_type == "VALSET_STRESS" {

--- a/orchestrator/test_runner/src/orch_keys_update.rs
+++ b/orchestrator/test_runner/src/orch_keys_update.rs
@@ -30,7 +30,7 @@ pub async fn orch_keys_update(
     info!("About to check already set delegate addresses");
     for k in keys.iter() {
         let eth_address = k.eth_key.to_public_key().unwrap();
-        let orch_address = k.orch_key.to_public_key().unwrap().to_address();
+        let orch_address = k.orch_key.to_address(&contact.get_prefix()).unwrap();
         let eth_response = grpc_client
             .get_delegate_key_by_eth(QueryDelegateKeysByEthAddress {
                 eth_address: eth_address.to_string(),
@@ -69,17 +69,18 @@ pub async fn orch_keys_update(
         // update the keys in the key list
         k.eth_key = eth_key;
         k.orch_key = cosmos_key;
+        let cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
 
         info!(
             "Signing and submitting Delegate addresses {} for validator {}",
             eth_key.to_public_key().unwrap(),
-            cosmos_key.to_public_key().unwrap().to_address(),
+            cosmos_address,
         );
         // send in the new delegate keys signed by the validator address
         updates.push(update_gravity_delegate_addresses(
             &contact,
             eth_key.to_public_key().unwrap(),
-            cosmos_key.to_public_key().unwrap().to_address(),
+            cosmos_address,
             k.validator_key,
             get_fee(),
         ));


### PR DESCRIPTION
This patch adds support for custom prefixes. To allow for chains with
different address prefixes than the default 'cosmos'.

Sadly this requires the user to specify the prefix as an argument when
launching the orchestrator. There's no way around this until a future
version of Cosmos exposes the prefix to clients. Looking upstream the
work for this seems to be in progress.